### PR TITLE
adding in update to the base class

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,16 +37,31 @@ class Datastore {
     }
 
     /**
-     * Save or create a record in the datastore
+     * Create a record in the datastore
      * @method save
      * @param  {Object}   config                Configuration
      * @param  {String}   config.table          table name
      * @param  {Object}   config.params         record data
-     * @param  {Object}   [config.params.id]    Unique id
+     * @param  {String}   config.params.id      Unique id
      * @param  {Function} callback
      */
     save() {
         console.error('save is not implemented');
+        throw new Error('not implemented');
+    }
+
+    /**
+     * Update a record in the datastore.
+     * Requires record to already exists
+     * @method save
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.table          table name
+     * @param  {Object}   config.params         record data
+     * @param  {String}   config.params.id      Unique id
+     * @param  {Function} callback
+     */
+    update() {
+        console.error('update is not implemented');
         throw new Error('not implemented');
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,7 @@ describe('index test', () => {
         assert.throws(instance.save, Error, 'not implemented');
         assert.throws(instance.scan, Error, 'not implemented');
         assert.throws(instance.remove, Error, 'not implemented');
+        assert.throws(instance.update, Error, 'not implemented');
     });
 
     it('can be extended', (done) => {


### PR DESCRIPTION
This PR is adding an update method to the datastore base class.

This function should be used for updating/merging data into the datastore from an object that already exists.

This differs from the save function, which is used for saving the entire data object.

This is to make it so we are not overloading the `save` function to switch on whether or not the config.params.id is passed into the function
