### PR TITLE
Adding input validation to base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 > Base class defining the interface for datastore implementations
 
+This base class should be used for defining different datastore options for the screwdriver api.
+The functions exposed contain input validation for to define the contract for datastores so that it
+is agnostic of the actual implementation.
+
 ## Usage
 
 ```bash
@@ -10,11 +14,10 @@ npm install screwdriver-datastore-base
 ```
 
 ## Extending
-*subject to change*
 ```js
 class MyDatastore extends Datastore {
     // Implement the interface
-    get(config, callback) {
+    _get(config, callback) {
 
         // do something to fetch data...
 
@@ -29,11 +32,29 @@ class MyDatastore extends Datastore {
 }
 
 const store = new MyDatastore({});
-store.get({ params: { id: 1 } }, (err, data) => {
+store.get({ table: 'tablename', params: { id: 1 } }, (err, data) => {
     // do something....
 });
 ```
-## Expected inputs and outputs for datastore implementations
+
+The base class exposes a set of functions:
+* `get`
+* `save`
+* `update`
+* `scan`
+* `remove`
+
+All of those functions provide input validation on the config object being passed in,
+and call an underlying function with the arguments passed in.
+
+To take advantage of the input validation, override these functions:
+* `_get`
+* `_save`
+* `_update`
+* `_scan`
+* `_remove`
+
+## Validation
 
 ### get
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
-/* eslint-disable no-console */
+/* eslint-disable no-underscore-dangle */
+const Joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const datastoreSchema = schema.plugins.datastore;
 
 class Datastore {
     /**
@@ -28,12 +31,21 @@ class Datastore {
      * @param  {Object}   config            Configuration
      * @param  {String}   config.table      Table name
      * @param  {Object}   config.params     Query params
-     * @param  {Object}   config.params.id  Unique id
+     * @param  {String}   config.params.id  Unique id
      * @param  {Function} callback          fn(err, data)
      */
-    get() {
-        console.error('get is not implemented');
-        throw new Error('not implemented');
+    get(config, callback) {
+        const result = Joi.validate(config, datastoreSchema.get);
+
+        if (result.error) {
+            return callback(result.error);
+        }
+
+        return this._get(config, callback);
+    }
+
+    _get(config, callback) {
+        callback(new Error('not implemented'));
     }
 
     /**
@@ -46,9 +58,18 @@ class Datastore {
      * @param  {Object}   config.params.data    The data to save
      * @param  {Function} callback              fn(err, data)
      */
-    save() {
-        console.error('save is not implemented');
-        throw new Error('not implemented');
+    save(config, callback) {
+        const result = Joi.validate(config, datastoreSchema.save);
+
+        if (result.error) {
+            return callback(result.error);
+        }
+
+        return this._save(config, callback);
+    }
+
+    _save(config, callback) {
+        callback(new Error('not implemented'));
     }
 
     /**
@@ -58,13 +79,22 @@ class Datastore {
      * @param  {Object}   config                Configuration
      * @param  {String}   config.table          Table name
      * @param  {Object}   config.params         Record data
-     * @param  {Object}   config.params.data    The data to save
      * @param  {String}   config.params.id      Unique id
+     * @param  {Object}   config.params.data    The data to save
      * @param  {Function} callback              fn(err, data)
      */
-    update() {
-        console.error('update is not implemented');
-        throw new Error('not implemented');
+    update(config, callback) {
+        const result = Joi.validate(config, datastoreSchema.update);
+
+        if (result.error) {
+            return callback(result.error);
+        }
+
+        return this._update(config, callback);
+    }
+
+    _update(config, callback) {
+        callback(new Error('not implemented'));
     }
 
     /**
@@ -78,9 +108,18 @@ class Datastore {
      * @param  {Number}   config.paginate.page  Specific page of the set to return
      * @param  {Function} callback              fn(err, data)
      */
-    scan() {
-        console.error('scan is not implemented');
-        throw new Error('not implemented');
+    scan(config, callback) {
+        const result = Joi.validate(config, datastoreSchema.scan);
+
+        if (result.error) {
+            return callback(result.error);
+        }
+
+        return this._scan(config, callback);
+    }
+
+    _scan(config, callback) {
+        callback(new Error('not implemented'));
     }
 
     /**
@@ -92,9 +131,18 @@ class Datastore {
      * @param  {Object}   config.params.id  Unique id
      * @param  {Function} callback
      */
-    remove() {
-        console.error('remove is not implemented');
-        throw new Error('not implemented');
+    remove(config, callback) {
+        const result = Joi.validate(config, datastoreSchema.remove);
+
+        if (result.error) {
+            return callback(result.error);
+        }
+
+        return this._remove(config, callback);
+    }
+
+    _remove(config, callback) {
+        callback(new Error('not implemented'));
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-base",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Base class defining the interface for datastore implementations",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,11 @@
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",
-    "jenkins-mocha": "^2.6.0"
+    "jenkins-mocha": "^2.6.0",
+    "mockery": "^1.7.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "joi": "^9.0.1",
+    "screwdriver-data-schema": "^5.0.0"
+  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,33 +1,215 @@
 'use strict';
+/* eslint-disable no-underscore-dangle */
 const assert = require('chai').assert;
-const Datastore = require('../index');
+const Joi = require('joi');
+const mockery = require('mockery');
 
 describe('index test', () => {
     let instance;
+    let Datastore;
+    let schemaMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
 
     beforeEach(() => {
+        schemaMock = {
+            plugins: {
+                datastore: {
+                    get: Joi.object().keys({
+                        table: Joi.string().required(),
+                        params: Joi.object().required()
+                    }),
+                    save: Joi.object().keys({
+                        table: Joi.string().required(),
+                        params: Joi.object().required()
+                    }),
+                    update: Joi.object().keys({
+                        table: Joi.string().required(),
+                        params: Joi.object().required()
+                    }),
+                    scan: Joi.object().keys({
+                        table: Joi.string().required(),
+                        paginate: Joi.object().required()
+                    }),
+                    remove: Joi.object().keys({
+                        table: Joi.string().required(),
+                        params: Joi.object().required()
+                    })
+                }
+            }
+        };
+        mockery.registerMock('screwdriver-data-schema', schemaMock);
+
+        /* eslint-disable global-require */
+        Datastore = require('../index');
+        /* eslint-enable global-require */
+
         instance = new Datastore({ foo: 'bar' });
     });
 
     afterEach(() => {
         instance = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
     });
 
     it('can create a datastore base class', () => {
         assert.instanceOf(instance, Datastore);
     });
 
-    it('has methods that need to be extended', () => {
-        assert.throws(instance.get, Error, 'not implemented');
-        assert.throws(instance.save, Error, 'not implemented');
-        assert.throws(instance.scan, Error, 'not implemented');
-        assert.throws(instance.remove, Error, 'not implemented');
-        assert.throws(instance.update, Error, 'not implemented');
+    describe('configure', () => {
+        it('has a configure method', () => {
+            assert.isFunction(instance.configure);
+            instance.configure({});
+        });
+    });
+
+    describe('get', () => {
+        it('returns error when invalid config object', (done) => {
+            instance.get({}, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+                done();
+            });
+        });
+
+        it('returns not implemented if config object is valid and _get not overridden', (done) => {
+            const config = {
+                table: 'tableName',
+                params: {
+                    id: 'a5d3'
+                }
+            };
+
+            instance.get(config, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /not implemented/);
+                done();
+            });
+        });
+    });
+
+    describe('save', () => {
+        it('returns error when invalid config object', (done) => {
+            instance.save({}, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+                done();
+            });
+        });
+
+        it('returns error if config object is valid and _save not overridden', (done) => {
+            const config = {
+                table: 'tableName',
+                params: {
+                    id: 'a5d3',
+                    data: {
+                        foo: 'bar'
+                    }
+                }
+            };
+
+            instance.save(config, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /not implemented/);
+                done();
+            });
+        });
+    });
+
+    describe('update', () => {
+        it('returns error when invalid config object', (done) => {
+            instance.update({}, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+                done();
+            });
+        });
+
+        it('returns error if config object is valid and _update not overridden', (done) => {
+            const config = {
+                table: 'tableName',
+                params: {
+                    id: 'a5d3',
+                    data: {
+                        foo: 'bar'
+                    }
+                }
+            };
+
+            instance.update(config, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /not implemented/);
+                done();
+            });
+        });
+    });
+
+    describe('scan', () => {
+        it('returns error when invalid config object', (done) => {
+            instance.scan({}, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+                done();
+            });
+        });
+
+        it('returns error if config object is valid and _scan not overridden', (done) => {
+            const config = {
+                table: 'tableName',
+                paginate: {
+                    count: 1,
+                    page: 40
+                }
+            };
+
+            instance.scan(config, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /not implemented/);
+                done();
+            });
+        });
+    });
+
+    describe('remove', () => {
+        it('returns error when invalid config object', (done) => {
+            instance.remove({}, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+                done();
+            });
+        });
+
+        it('returns error if config object is valid and _scan not overridden', (done) => {
+            const config = {
+                table: 'tableName',
+                params: {
+                    id: 'a5d4'
+                }
+            };
+
+            instance.remove(config, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /not implemented/);
+                done();
+            });
+        });
     });
 
     it('can be extended', (done) => {
         class Foo extends Datastore {
-            get(id, callback) {
+            _get(config, callback) {
+                const id = config.params.id;
+
                 if (id > 0) {
                     return callback(null, { id });
                 }
@@ -41,7 +223,12 @@ describe('index test', () => {
         const bar = new Foo({ foo: 'bar' });
 
         assert.instanceOf(bar, Datastore);
-        bar.get(1, (err, data) => {
+        bar.get({
+            table: 'tableName',
+            params: {
+                id: 1
+            }
+        }, (err, data) => {
             assert.isNull(err);
             assert.equal(data.id, 1);
             done();


### PR DESCRIPTION
This PR is adding in the input validation to the base class. It is taking advantage of schema that is defined in the `screwdriver-data-schema`

Updates the README to describe how to take advantage of the validation and provides intent for this base class
