### PR TITLE
Rename to new repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [npm-url]: https://npmjs.org/package/screwdriver-datastore-base
 [downloads-image]: https://img.shields.io/npm/dt/screwdriver-datastore-base.svg
 [license-image]: https://img.shields.io/npm/l/screwdriver-datastore-base.svg
-[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver-datastore-base.svg
-[issues-url]: https://github.com/screwdriver-cd/screwdriver-datastore-base/issues
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/datastore-base.svg
+[issues-url]: https://github.com/screwdriver-cd/datastore-base/issues
 [wercker-image]: https://app.wercker.com/status/fbf5553a4f8821567edc6394e976f4ab
 [wercker-url]: https://app.wercker.com/project/bykey/fbf5553a4f8821567edc6394e976f4ab
-[daviddm-image]: https://david-dm.org/screwdriver-cd/screwdriver-datastore-base.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/screwdriver-cd/screwdriver-datastore-base
+[daviddm-image]: https://david-dm.org/screwdriver-cd/datastore-base.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/screwdriver-cd/datastore-base

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/screwdriver-datastore-base.git"
+    "url": "git@github.com:screwdriver-cd/datastore-base.git"
   },
-  "homepage": "https://github.com/screwdriver-cd/screwdriver-datastore-base",
-  "bugs": "https://github.com/screwdriver-cd/screwdriver-datastore-base/issues",
+  "homepage": "https://github.com/screwdriver-cd/datastore-base",
+  "bugs": "https://github.com/screwdriver-cd/datastore-base/issues",
   "keywords": [
     "screwdriver",
     "yahoo"


### PR DESCRIPTION
This repository seems to be renamed from "screwdriver-datastore-base" to "datastore-base". GitHub basically redirects from old name to new name, but I think we should use new repository name.
