### PR TITLE
Renaming `configure` to `setup` and supporting a promise interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ To take advantage of the input validation, override these functions:
 * `_scan`
 * `_remove`
 
+Additionally, there is a `setup` function which will be called by Screwdriver to allow the
+datastore to create or upgrade tables as needed.
+
 ## Interface
 
 ### get

--- a/index.js
+++ b/index.js
@@ -33,13 +33,12 @@ class Datastore {
     }
 
     /**
-     * Reload configuration
-     * @method configure
-     * @param  {Object}     config      Configuration
-     * @param  {Function}   [callback]
+     * Setup database connections and get tables in order
+     * @method setup
+     * @return Promise
      */
-    configure(config) {
-        this.config = config;
+    setup() {
+        return Promise.resolve();
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-base",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Base class defining the interface for datastore implementations",
   "main": "index.js",
   "scripts": {
@@ -32,9 +32,9 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0",
-    "mockery": "^1.7.0"
+    "eslint-plugin-import": "^2.0.0",
+    "jenkins-mocha": "^3.0.0",
+    "mockery": "^2.0.0"
   },
   "dependencies": {
     "joi": "^9.0.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,10 +66,11 @@ describe('index test', () => {
         assert.instanceOf(instance, Datastore);
     });
 
-    describe('configure', () => {
-        it('has a configure method', () => {
-            assert.isFunction(instance.configure);
-            instance.configure({});
+    describe('setup', () => {
+        it('has a setup method', () => {
+            assert.isFunction(instance.setup);
+
+            return instance.setup();
         });
     });
 


### PR DESCRIPTION
This is not used anywhere right now, but after this we can start doing DB setup like creating tables when the server starts.

Also upgrading packages.
