### PR TITLE
fix: reject with err object instead of string

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class Datastore {
     }
 
     _get() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -72,7 +72,7 @@ class Datastore {
     }
 
     _save() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -90,7 +90,7 @@ class Datastore {
     }
 
     _update() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -109,7 +109,7 @@ class Datastore {
     }
 
     _scan() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -126,7 +126,7 @@ class Datastore {
     }
 
     _remove() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 }
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -100,7 +100,7 @@ describe('index test', function () {
                     throw new Error('Oops');
                 }, (err) => {
                     assert.isOk(err, 'Error should be returned');
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 });
         });
     });
@@ -132,7 +132,7 @@ describe('index test', function () {
                     throw new Error('Oops');
                 }, (err) => {
                     assert.isOk(err, 'Error should be returned');
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 });
         });
     });
@@ -164,7 +164,7 @@ describe('index test', function () {
                     throw new Error('Oops');
                 }, (err) => {
                     assert.isOk(err, 'Error should be returned');
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 });
         });
     });
@@ -194,7 +194,7 @@ describe('index test', function () {
                     throw new Error('Oops');
                 }, (err) => {
                     assert.isOk(err, 'Error should be returned');
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 });
         });
     });
@@ -223,7 +223,7 @@ describe('index test', function () {
                     throw new Error('Oops');
                 }, (err) => {
                     assert.isOk(err, 'Error should be returned');
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 });
         });
     });


### PR DESCRIPTION
Reject with error object instead of string.

This is giving us problem when we catch the err in the API and try to wrap it with `boom.wrap(err)`. `boom.wrap` assumes `err` is an error object.
https://github.com/hapijs/boom#wraperror-statuscode-message