### PR TITLE
feat(1967): Add ability to do raw query. BREAKING CHANGE: throws err when query function not implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The base class exposes a set of functions:
 * `update`
 * `scan`
 * `remove`
+* `query`
 
 All of those functions provide input validation on the config object being passed in,
 and call an underlying function with the arguments passed in.
@@ -52,6 +53,7 @@ To take advantage of the input validation, override these functions:
 * `_update`
 * `_scan`
 * `_remove`
+* `_query`
 
 Additionally, there is a `setup` function which will be called by Screwdriver to allow the
 datastore to create or upgrade tables as needed.
@@ -142,6 +144,22 @@ A promise that resolves to an array of records, or rejects if fails.
 #### Example datastores
 - [screwdriver-datastore-imdb](https://github.com/screwdriver-cd/datastore-imdb)
 - [screwdriver-datastore-dynamodb](https://github.com/screwdriver-cd/datastore-dynamodb)
+
+### query
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+|config | Object | Each of its properties defines your operation |
+|config.table | String | The datastore table name |
+|config.queries| Array | Map of datastore type to related query |
+|config.replacements| Object | Each of its properties are parameters that are replaced in the query |
+|config.rawResponse| Boolean | Whether to return raw response or bind to model associated with table |
+
+#### Expected Outcome
+The query function is expected to run one of the given queries, based on datastore type, and return the response, either as raw data or bound to a model.
+
+#### Expected Return
+A promise that resolves to an array of records, or rejects if fails.
 
 
 ## Testing

--- a/index.js
+++ b/index.js
@@ -113,6 +113,24 @@ class Datastore {
     }
 
     /**
+     * Run raw query on the datastore
+     * @method query
+     * @param  {Object}        config                Configuration object
+     * @param  {Array<Object>} [config.queries]      Map of database type to query
+     * @param  {String}        [config.table]        Table name
+     * @param  {Object}        [config.replacements] Parameters to replace in the query
+     * @param  {Boolean}       [config.rawResponse]  Return raw response
+     */
+    query(config) {
+        return validate(config, datastoreSchema.query)
+            .then(validConfig => this._query(validConfig));
+    }
+
+    _query() {
+        return Promise.reject(new Error('Not implemented'));
+    }
+
+    /**
      * Remove a single record given an id
      * @method remove
      * @param  {Object}   config            Configuration

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ class Datastore {
      * @param  {Array<Object>} [config.queries]      Map of database type to query
      * @param  {String}        [config.table]        Table name
      * @param  {Object}        [config.replacements] Parameters to replace in the query
-     * @param  {Boolean}       [config.rawResponse]  Return raw response
+     * @param  {Boolean}       [config.rawResponse]  Return raw response without binding to model
      */
     query(config) {
         return validate(config, datastoreSchema.query)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,6 +39,14 @@ describe('index test', function () {
                         table: Joi.string().required(),
                         paginate: Joi.object().required()
                     }),
+                    query: Joi.object().keys({
+                        table: Joi.string().required(),
+                        queries: Joi.array().items(
+                            Joi.object().keys({
+                                dbType: Joi.string().required(),
+                                query: Joi.string().required()
+                            })).required()
+                    }),
                     remove: Joi.object().keys({
                         table: Joi.string().required(),
                         params: Joi.object().required()
@@ -190,6 +198,36 @@ describe('index test', function () {
             };
 
             return instance.scan(config)
+                .then(() => {
+                    throw new Error('Oops');
+                }, (err) => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.message, 'Not implemented');
+                });
+        });
+    });
+
+    describe('query', () => {
+        it('returns error when invalid config object', () =>
+            instance.query({})
+                .then(() => {
+                    throw new Error('Oops');
+                }, (err) => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
+
+        it('returns error if config object is valid and _scan not overridden', () => {
+            const config = {
+                table: 'tableName',
+                queries: [{
+                    dbType: 'postgres',
+                    query: 'SELECT * FROM builds'
+                }]
+            };
+
+            return instance.query(config)
                 .then(() => {
                     throw new Error('Oops');
                 }, (err) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -218,7 +218,7 @@ describe('index test', function () {
                 })
         );
 
-        it('returns error if config object is valid and _scan not overridden', () => {
+        it('returns error if config object is valid and _query not overridden', () => {
             const config = {
                 table: 'tableName',
                 queries: [{


### PR DESCRIPTION
## Context

Need to add the ability to do raw queries to datastore so queries that are otherwise impossible to do through sequelize can be done.

## Objective

Add a query method to datastore.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1967

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
