### PR TITLE
feat(1958): Upgrade hapi dependencies. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 /* eslint-disable no-underscore-dangle */
-const Joi = require('joi');
 const dataSchema = require('screwdriver-data-schema');
 const datastoreSchema = dataSchema.plugins.datastore;
 
@@ -13,7 +12,7 @@ const datastoreSchema = dataSchema.plugins.datastore;
 * @return {Promise}
 */
 function validate(config, schema) {
-    const result = Joi.validate(config, schema);
+    const result = schema.validate(config);
 
     if (result.error) {
         return Promise.reject(result.error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-base",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Base class defining the interface for datastore implementations",
   "main": "index.js",
   "scripts": {
@@ -43,7 +43,7 @@
     "mockery": "^2.1.0"
   },
   "dependencies": {
-    "@hapi/joi": "^17.1.1",
+    "joi": "^17.2.0",
     "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-base",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Base class defining the interface for datastore implementations",
   "main": "index.js",
   "scripts": {
@@ -44,6 +44,6 @@
   },
   "dependencies": {
     "joi": "^17.2.0",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
+    "screwdriver-data-schema": "^20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive --timeout 4000 --retries 1 --exit --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -39,11 +39,11 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "mocha": "^8.1.0",
     "mockery": "^2.1.0"
   },
   "dependencies": {
-    "joi": "^13.7.0",
-    "screwdriver-data-schema": "^19.1.1"
+    "@hapi/joi": "^17.1.1",
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const mockery = require('mockery');
 
 describe('index test', function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const mockery = require('mockery');
 
 describe('index test', function () {


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
