### PR TITLE
Revert Revert "feat(3171): Move pipeline template workflowGraph out of config into a new field"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-base",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Base class defining the interface for datastore implementations",
   "main": "index.js",
   "scripts": {
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "joi": "^17.7.0",
-    "screwdriver-data-schema": "^23.0.4"
+    "screwdriver-data-schema": "^24.0.0"
   }
 }


### PR DESCRIPTION
Reverts screwdriver-cd/datastore-base#45

feat(3171): Move pipeline template workflowGraph out of config into a new field

BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

Upgrading dependencies

https://github.com/screwdriver-cd/screwdriver/issues/3171